### PR TITLE
Make si request in parallel

### DIFF
--- a/src/si/scrap.js
+++ b/src/si/scrap.js
@@ -2,7 +2,7 @@ const cheerio = require('cheerio')
 
 const URI = require('./url.json').url
 
-const extractFromHTML = (data) => {
+const extractFromHTML = (data, includeMaxPage = false) => {
   const $ = cheerio.load(data)
   const baseUrl = URI.slice(0, -1)
   const results = []
@@ -40,7 +40,13 @@ const extractFromHTML = (data) => {
     results.push(toPush)
   })
 
-  return results
+  if (includeMaxPage) {
+    return includeMaxPage
+      ? { results, maxPage: +$('ul.pagination li:nth-last-child(2) a').text() }
+      : results
+  } else {
+    return results
+  }
 }
 
 module.exports = {


### PR DESCRIPTION
### Query: "F" (14 pages)
```
Before
si: 15241.757ms
After
si: 6218.550ms
```

### Query: "Darling" (4 pages)
```
Before
si: 4438.146ms
After
si: 2333.308ms
```