### PR TITLE
fix: pantsu checkHeader error

### DIFF
--- a/src/pantsu/header.js
+++ b/src/pantsu/header.js
@@ -17,8 +17,8 @@ const checkHeader = (id) => {
       return
     }
 
-    request.head(`${URI}view/${id}`)
-      .then((data) => resolve(JSON.parse(data)))
+    request.get(`${URI}view/${id}`)
+      .on('response', (response) => resolve(response.statusMessage))
       .catch((err) => reject(err))
   })
 }


### PR DESCRIPTION
currently function throws error when parsing, since head data is already in json format

now returns statusmessage according to Nyaa Pantsu API docs
https://nyaa.net/apidoc/#api-Torrents-GetTorrentHead