### PR TITLE
Adds list methods and infoRequest for si

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ console.log(si)
 console.log(pantsu)
 /**
  * [Pantsu] methods:
+ *   > list
  *   > search
  *   > searchAll
  *   > infoRequest

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ const {si, pantsu} = require('nyaapi')
 console.log(si)
 /**
  * [Si] methods:
+ *   > list
  *   > search
  *   > searchAll
  *   > searchPage

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ console.log(si)
  *   > searchByUser
  *   > searchAllByUser
  *   > searchByUserAndByPage
+ *   > infoRequest
  *   > upload
  * 
  */

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nyaapi",
-  "version": "2.1.3",
+  "version": "2.2.0",
   "description": "Non-official api for getting torrent links from Nyaa.si and Nyaa.pantsu.cat",
   "main": "src/index.js",
   "scripts": {

--- a/src/pantsu/index.js
+++ b/src/pantsu/index.js
@@ -1,4 +1,4 @@
-const { search, searchAll } = require('./search.js')
+const { list, search, searchAll } = require('./search.js')
 const { infoRequest } = require('./info.js')
 const { upload } = require('./upload.js')
 const { update } = require('./update.js')
@@ -7,6 +7,7 @@ const { checkUser } = require('./checkUser.js')
 const { checkHeader } = require('./header.js')
 
 module.exports = {
+  list,
   search,
   searchAll,
   infoRequest,

--- a/src/pantsu/search.js
+++ b/src/pantsu/search.js
@@ -77,7 +77,39 @@ const searchAll = async (term, opts = {}) => {
   return results
 }
 
+/**
+ *
+ * List specific category on nyaa.pantsu.cat
+ *
+ * @param {string} c    Category to list.
+ * @param {number} p    Page of the category.
+ * @param {Object} opts Research options as described on the official documentation (optional).
+ *
+ * @returns {promise}
+ */
+
+const list = (c, p = 1, opts = {}) => {
+  return new Promise((resolve, reject) => {
+    if (typeof c === 'object') {
+      opts = c
+      c = opts.c
+    }
+
+    opts.c = c || []
+    opts.page = p || 1
+    opts.limit = opts.n || 100
+    opts = omit(opts, 'n')
+
+    request.get(URI + 'search', {
+      qs: opts
+    })
+      .then((data) => resolve(JSON.parse(data).torrents))
+      .catch(/* istanbul ignore next */ (err) => reject(err))
+  })
+}
+
 module.exports = {
+  list,
   search,
   searchAll
 }

--- a/src/si/index.js
+++ b/src/si/index.js
@@ -1,7 +1,8 @@
-const { search, searchAll, searchAllByUser, searchByUser, searchByUserAndByPage, searchPage } = require('./search.js')
+const { list, search, searchAll, searchAllByUser, searchByUser, searchByUserAndByPage, searchPage } = require('./search.js')
 const { upload } = require('./upload.js')
 
 module.exports = {
+  list,
   search,
   searchAll,
   searchPage,

--- a/src/si/index.js
+++ b/src/si/index.js
@@ -1,4 +1,5 @@
 const { list, search, searchAll, searchAllByUser, searchByUser, searchByUserAndByPage, searchPage } = require('./search.js')
+const { infoRequest } = require('./info.js')
 const { upload } = require('./upload.js')
 
 module.exports = {
@@ -9,5 +10,6 @@ module.exports = {
   searchByUser,
   searchAllByUser,
   searchByUserAndByPage,
+  infoRequest,
   upload
 }

--- a/src/si/info.js
+++ b/src/si/info.js
@@ -1,0 +1,30 @@
+const request = require('request-promise')
+const { extractPageFromHTML } = require('./scrap.js')
+
+const URI = require('./url.json').url
+
+/**
+ * Request torrent information according to its ID.
+ *
+ * @param {number} id The ID of the torrent you want information of.
+ *
+ * @returns {promise}
+ */
+
+const infoRequest = (id) => {
+  return new Promise((resolve, reject) => {
+    if (!id) {
+      reject(new Error('[Nyaapi]: No ID given on request demand.'))
+      return
+    }
+
+    request.get(`${URI}view/${id}`)
+      .then((data) => resolve(extractPageFromHTML(data)))
+      .then((info) => ({ id, ...info }))
+      .catch(/* istanbul ignore next */ (err) => reject(err))
+  })
+}
+
+module.exports = {
+  infoRequest
+}

--- a/src/si/scrap.js
+++ b/src/si/scrap.js
@@ -50,6 +50,28 @@ const extractFromHTML = (data, includeMaxPage = false) => {
   }
 }
 
+const extractPageFromHTML = (data) => {
+  const $ = cheerio.load(data)
+  const baseUrl = URI.slice(0, -1)
+
+  return {
+    name: $('.panel-heading > .panel-title').eq(0).text().trim(),
+    hash: $('div > kbd').text().trim().toLowerCase(),
+    date: new Date($('div[class="col-md-1"]:contains("Date:")').next().attr('data-timestamp') * 1000).toISOString(),
+    filesize: $('div[class="col-md-1"]:contains("File size:")').next().text(),
+    description: $('#torrent-description').text(),
+    category: $('div[class="col-md-5"] > a').eq(0).attr('href').replace('/?c=', ''),
+    sub_category: $('div[class="col-md-5"] > a').eq(1).attr('href').replace('/?c=', ''),
+    uploader_name: $('div[class="col-md-1"]:contains("Submitter:")').next().text().trim(),
+    magnet: $('.panel-footer > a').eq(1).attr('href'),
+    torrent: baseUrl + $('.panel-footer > a').eq(0).attr('href'),
+    seeders: $('div[class="col-md-1"]:contains("Seeders:")').next().children().first().text(),
+    leechers: $('div[class="col-md-1"]:contains("Leechers:")').next().children().first().text(),
+    completed: $('div[class="col-md-1"]:contains("Completed:")').next().text()
+  }
+}
+
 module.exports = {
-  extractFromHTML
+  extractFromHTML,
+  extractPageFromHTML
 }

--- a/src/si/search.js
+++ b/src/si/search.js
@@ -261,7 +261,43 @@ const searchByUser = async (user = null, term = '', n = null, opts = {}) => {
   }
 }
 
+/**
+ * List specific category on nyaa.si.
+ *
+ * @param {string} c    Category to list.
+ * @param {number} p    Page of the category.
+ * @param {object} opts Research options as described on the documentation.
+ *
+ * @returns {promise}
+ */
+
+const list = (c, p = 1, opts = {}) => {
+  return new Promise((resolve, reject) => {
+    if (typeof c === 'object') {
+      opts = c
+      c = opts.c
+      p = p || opts.p
+    }
+
+    request.get(URI, {
+      qs: {
+        f: opts.filter || 0,
+        c: c || '1_0',
+        p: p,
+        s: opts.sort || 'id',
+        o: opts.direction || 'desc'
+      }
+    })
+      .then((data) => {
+        const results = extractFromHTML(data, true)
+        resolve(results)
+      })
+      .catch(/* istanbul ignore next */ (err) => reject(err))
+  })
+}
+
 module.exports = {
+  list,
   search,
   searchAll,
   searchPage,


### PR DESCRIPTION
 - Adds `list` method for `pantsu` to list torrent for category (optional) without searching
 - Adds `list` method for `si` to list torrent for category (optional) without searching
 - Adds `infoRequest` method for `si` to retrieve info for specific entry. Uses the same definition as `pantsu` api for easier inter-op.