### PR TITLE
Fix undefined scrap error

### DIFF
--- a/src/si/scrap.js
+++ b/src/si/scrap.js
@@ -14,11 +14,11 @@ function extractFromHTML (data, includeMaxPage = false) {
   $('tr').slice(1).each(function () {
     // speical handling for hash, as very rarely the download option will be unavailable and missing.
     let hash = ""
-    let hashElement = _getChild(this, 3).find('a:nth-child(2)').attr('href')
-    if (!hashElement) 
-      hashElement = _getChild(this, 3).find('a:nth-child(1)').attr('href')
-    if (hashElement)
-      hash = hashElement.match(/btih:(\w+)/)[1]
+    let magnetElement = _getChild(this, 3).find('a:nth-child(2)').attr('href')
+    if (!magnetElement) 
+      magnetElement = _getChild(this, 3).find('a:nth-child(1)').attr('href')
+    // magnetElement is assumed to be valid, if the magnet option is unavailable the torrent wouldn't be present.
+    hash = magnetElement.match(/btih:(\w+)/)[1]
 
     const result = {
       id: _getChild(this, 2).find('a:not(.comments)').attr('href').replace('/view/', ''),
@@ -28,7 +28,7 @@ function extractFromHTML (data, includeMaxPage = false) {
       filesize: _getChild(this, 4).text(),
       category: _getChild(this, 1).find('a').attr('href').replace('/?c=', '').replace(/\d{1,2}$/, '0'),
       sub_category: _getChild(this, 1).find('a').attr('href').replace('/?c=', ''),
-      magnet: _getChild(this, 3).find('a:nth-child(2)').attr('href'),
+      magnet: magnetElement,
       torrent: baseUrl + _getChild(this, 3).find('a:nth-child(1)').attr('href'),
       seeders: _getChild(this, 6).text(),
       leechers: _getChild(this, 7).text(),

--- a/src/si/scrap.js
+++ b/src/si/scrap.js
@@ -12,10 +12,18 @@ function extractFromHTML (data, includeMaxPage = false) {
   }
 
   $('tr').slice(1).each(function () {
+    // speical handling for hash, as very rarely the download option will be unavailable and missing.
+    let hash = ""
+    let hashElement = _getChild(this, 3).find('a:nth-child(2)').attr('href')
+    if (!hashElement) 
+      hashElement = _getChild(this, 3).find('a:nth-child(1)').attr('href')
+    if (hashElement)
+      hash = hashElement.match(/btih:(\w+)/)[1]
+
     const result = {
       id: _getChild(this, 2).find('a:not(.comments)').attr('href').replace('/view/', ''),
       name: _getChild(this, 2).find('a:not(.comments)').text().trim(),
-      hash: _getChild(this, 3).find('a:nth-child(2)').attr('href').match(/btih:(\w+)/)[1],
+      hash: hash,
       date: new Date(_getChild(this, 5).attr('data-timestamp') * 1000).toISOString(),
       filesize: _getChild(this, 4).text(),
       category: _getChild(this, 1).find('a').attr('href').replace('/?c=', '').replace(/\d{1,2}$/, '0'),


### PR DESCRIPTION
Handles an exceptional case when the download torrent file option is missing in a search.

## Error
```
(node:157123) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'match' of undefined
    at Node.<anonymous> (.../node_modules/nyaapi/src/si/scrap.js:18:67)
    at LoadedCheerio.each (.../node_modules/cheerio/lib/api/traversing.js:480:26)
    ...
```
## Reproduction Steps
```
let results = await si.search("Kidou Senshi Gundam", 75, {
    category: '1_2',
    sort: 'seeders',
    p: 1
})
```

For example above would generate: https://nyaa.si/?f=0&c=1_2&q=Kidou+Senshi+Gundam&s=seeders&o=desc
With one of the entries missing the download option seen below:
![image](https://user-images.githubusercontent.com/10760766/169664506-6e507c12-e5d8-45f8-9951-5d09d42a75c6.png)
